### PR TITLE
Refactor contact viewsets and model admins

### DIFF
--- a/community/wagtail_hooks.py
+++ b/community/wagtail_hooks.py
@@ -10,53 +10,10 @@ from wagtail import hooks
 
 from accounts.models import User
 from community.models import CommunityDirectory, OnlineWorship
-from contact.models import Meeting, Organization, Person
 from documents.models import MeetingDocument, PublicBoardDocument
 from events.models import Event
 from memorials.models import Memorial
 from wf_pages.models import MollyWingateBlogPage
-
-
-class PersonModelAdmin(ModelAdmin):
-    model = Person
-    menu_icon = "user"
-    menu_label = "People"
-    list_per_page = 10
-    ordering = ["family_name", "given_name"]
-    list_display = ("family_name", "given_name")
-    empty_value_display = "-"
-    search_fields = ("given_name", "family_name")
-
-    # TODO: determine why the following code does not work
-    # The goal is to load the js file in the admin
-    # only when the Person model is being edited
-    # rather than globally as we do at the end of this file
-    # form_view_extra_js = [
-    #     "js/contact/person_url_slug.js",
-    # ]
-
-
-class MeetingModelAdmin(ModelAdmin):
-    model = Meeting
-    menu_icon = "home"
-    menu_label = "Meetings"
-    list_per_page = 10
-    ordering = ["title"]
-    list_display = ("title", "meeting_type")
-    empty_value_display = "-"
-    search_fields = ("title",)
-    list_filter = ("meeting_type",)
-
-
-class OrganizationModelAdmin(ModelAdmin):
-    model = Organization
-    menu_icon = "group"
-    menu_label = "Organizations"
-    list_per_page = 10
-    ordering = ["title"]
-    list_display = ("title",)
-    empty_value_display = "-"
-    search_fields = ("title",)
 
 
 class MemorialModelAdmin(ModelAdmin):
@@ -227,9 +184,6 @@ class CommunityGroup(ModelAdminGroup):
     menu_order = 200
     items = (
         UserModelAdmin,
-        PersonModelAdmin,
-        MeetingModelAdmin,
-        OrganizationModelAdmin,
         EventModelAdmin,
         MemorialModelAdmin,
         CommunityDirectoryModelAdmin,

--- a/contact/views.py
+++ b/contact/views.py
@@ -49,6 +49,7 @@ class MeetingViewSet(PageListingViewSet):
     add_to_settings_menu = False
     search_fields = ["title"]
     filterset_class = MeetingFilterSet
+    ordering = ["title"]
 
 
 class OrganizationViewSet(PageListingViewSet):
@@ -58,6 +59,7 @@ class OrganizationViewSet(PageListingViewSet):
     name = "organizations"
     add_to_settings_menu = False
     search_fields = ["title"]
+    ordering = ["title"]
 
 
 class ContactViewSetGroup(ViewSetGroup):

--- a/contact/views.py
+++ b/contact/views.py
@@ -1,3 +1,4 @@
+from wagtail.admin.ui.tables import Column
 from wagtail.admin.viewsets.base import ViewSetGroup
 from wagtail.admin.viewsets.pages import PageListingViewSet
 
@@ -11,37 +12,52 @@ from .models import (
 class PersonViewSet(PageListingViewSet):
     model = Person
     menu_label = "People"
-    name = "Person"
+    name = "people"
     icon = "user"
     add_to_settings_menu = False
-    list_display = ["family_name", "given_name"]
+    columns = [
+        Column(
+            "given_name",
+            label="Given Name",
+            sort_key="given_name",
+        ),
+        Column(
+            "family_name",
+            label="Family Name",
+            sort_key="family_name",
+        ),
+    ]
     search_fields = ["given_name", "family_name"]
+    # Tried to add ordering to the columns, but it didn't work.
+    # https://stackoverflow.com/questions/78563124/how-to-specify-ordering-for-wagtal-pagelistingviewset
     ordering = ["family_name", "given_name"]
-    list_per_page = 10
+
+
+class MeetingFilterSet(PageListingViewSet.filterset_class):
+    class Meta:
+        model = Meeting
+        fields = [
+            "meeting_type",
+        ]
 
 
 class MeetingViewSet(PageListingViewSet):
     model = Meeting
     menu_label = "Meetings"
     icon = "home"
-    name = "Meeting"
+    name = "meetings"
     add_to_settings_menu = False
-    list_display = ["title", "meeting_type"]
     search_fields = ["title"]
-    ordering = ["title"]
-    list_per_page = 10
+    filterset_class = MeetingFilterSet
 
 
 class OrganizationViewSet(PageListingViewSet):
     model = Organization
     menu_label = "Organizations"
     icon = "group"
-    name = "Organization"
+    name = "organizations"
     add_to_settings_menu = False
-    list_display = ["title"]
     search_fields = ["title"]
-    ordering = ["title"]
-    list_per_page = 10
 
 
 class ContactViewSetGroup(ViewSetGroup):

--- a/contact/views.py
+++ b/contact/views.py
@@ -1,0 +1,55 @@
+from wagtail.admin.viewsets.base import ViewSetGroup
+from wagtail.admin.viewsets.pages import PageListingViewSet
+
+from .models import (
+    Meeting,
+    Organization,
+    Person,
+)
+
+
+class PersonViewSet(PageListingViewSet):
+    model = Person
+    menu_label = "People"
+    name = "Person"
+    icon = "user"
+    add_to_settings_menu = False
+    list_display = ["family_name", "given_name"]
+    search_fields = ["given_name", "family_name"]
+    ordering = ["family_name", "given_name"]
+    list_per_page = 10
+
+
+class MeetingViewSet(PageListingViewSet):
+    model = Meeting
+    menu_label = "Meetings"
+    icon = "home"
+    name = "Meeting"
+    add_to_settings_menu = False
+    list_display = ["title", "meeting_type"]
+    search_fields = ["title"]
+    ordering = ["title"]
+    list_per_page = 10
+
+
+class OrganizationViewSet(PageListingViewSet):
+    model = Organization
+    menu_label = "Organizations"
+    icon = "group"
+    name = "Organization"
+    add_to_settings_menu = False
+    list_display = ["title"]
+    search_fields = ["title"]
+    ordering = ["title"]
+    list_per_page = 10
+
+
+class ContactViewSetGroup(ViewSetGroup):
+    menu_label = "Contacts"
+    menu_icon = "group"
+    menu_order = 100
+    items = [
+        PersonViewSet,
+        MeetingViewSet,
+        OrganizationViewSet,
+    ]

--- a/contact/wagtail_hooks.py
+++ b/contact/wagtail_hooks.py
@@ -1,5 +1,6 @@
 from wagtail import hooks
 from .models import Meeting, Organization, Person
+from .views import ContactViewSetGroup
 
 
 @hooks.register("construct_queryset")
@@ -16,3 +17,8 @@ def prefetch_contact_related(queryset):
         )
 
     return queryset
+
+
+@hooks.register("register_admin_viewset")
+def register_contact_viewset_group():
+    return ContactViewSetGroup()

--- a/magazine/views.py
+++ b/magazine/views.py
@@ -40,7 +40,7 @@ class ArchiveIssueViewSet(PageListingViewSet):
     model = ArchiveIssue
     menu_label = "Archive Issues"
     icon = "doc-full"
-    add_to_admin_menu = True
+    add_to_admin_menu = False
     columns = [
         PageTitleColumn(
             "title",
@@ -75,7 +75,7 @@ class MagazineDepartmentViewSet(PageListingViewSet):
     model = MagazineDepartment
     menu_label = "Departments"
     icon = "tag"
-    add_to_admin_menu = True
+    add_to_admin_menu = False
     columns = [
         PageTitleColumn(
             "title",
@@ -97,7 +97,7 @@ class MagazineIssueViewSet(PageListingViewSet):
     model = MagazineIssue
     menu_label = "Issues"
     icon = "doc-full-inverse"
-    add_to_admin_menu = True
+    add_to_admin_menu = False
     search_fields = ("title",)
     filterset_class = MagazineIssueFilterSet
 

--- a/magazine/views.py
+++ b/magazine/views.py
@@ -39,6 +39,7 @@ class MagazineIssueFilterSet(PageListingViewSet.filterset_class):
 class ArchiveIssueViewSet(PageListingViewSet):
     model = ArchiveIssue
     menu_label = "Archive Issues"
+    name = "archive_issues"
     icon = "doc-full"
     add_to_admin_menu = False
     columns = [
@@ -68,12 +69,10 @@ class ArchiveIssueViewSet(PageListingViewSet):
     )
 
 
-archive_issue_viewset = ArchiveIssueViewSet("archive_issues")
-
-
 class MagazineDepartmentViewSet(PageListingViewSet):
     model = MagazineDepartment
     menu_label = "Departments"
+    name = "magazine_departments"
     icon = "tag"
     add_to_admin_menu = False
     columns = [
@@ -90,19 +89,14 @@ class MagazineDepartmentViewSet(PageListingViewSet):
     search_fields = ("title",)
 
 
-magazine_department_viewset = MagazineDepartmentViewSet("magazine_departments")
-
-
 class MagazineIssueViewSet(PageListingViewSet):
     model = MagazineIssue
     menu_label = "Issues"
+    name = "magazine_issues"
     icon = "doc-full-inverse"
     add_to_admin_menu = False
     search_fields = ("title",)
     filterset_class = MagazineIssueFilterSet
-
-
-magazine_issue_viewset = MagazineIssueViewSet("magazine_issues")
 
 
 class MagazineViewSetGroup(ViewSetGroup):
@@ -110,7 +104,7 @@ class MagazineViewSetGroup(ViewSetGroup):
     menu_icon = "tablet-alt"
     menu_order = 100
     items = (
-        archive_issue_viewset,
-        magazine_department_viewset,
-        magazine_issue_viewset,
+        ArchiveIssueViewSet,
+        MagazineDepartmentViewSet,
+        MagazineIssueViewSet,
     )


### PR DESCRIPTION
Related to #938 

This pull request refactors the contact viewsets and model admins to improve code organization and readability. It removes the admin menu registrations for the contact model admins and adds the ContactViewSetGroup to handle the viewsets for the Person, Meeting, and Organization models. This change also includes updates to the ordering, filters, and columns for the viewsets.