### PR TITLE
Add MemorialViewSet and Remove MemorialModelAdmin

### DIFF
--- a/community/wagtail_hooks.py
+++ b/community/wagtail_hooks.py
@@ -12,29 +12,7 @@ from accounts.models import User
 from community.models import CommunityDirectory, OnlineWorship
 from documents.models import MeetingDocument, PublicBoardDocument
 from events.models import Event
-from memorials.models import Memorial
 from wf_pages.models import MollyWingateBlogPage
-
-
-class MemorialModelAdmin(ModelAdmin):
-    """Memorial model admin."""
-
-    model = Memorial
-    menu_label = "Memorials"
-    menu_icon = "user"
-    menu_order = 295
-    add_to_settings_menu = False
-    exclude_from_explorer = False
-    list_display = (
-        "full_name",
-        "memorial_meeting",
-    )
-    list_filter = ("memorial_meeting",)
-    search_fields = (
-        "memorial_person__family_name",
-        "memorial_person__given_name",
-        "memorial_meeting__title",
-    )
 
 
 class MollyWingateBlogPageModelAdmin(ModelAdmin):
@@ -185,7 +163,6 @@ class CommunityGroup(ModelAdminGroup):
     items = (
         UserModelAdmin,
         EventModelAdmin,
-        MemorialModelAdmin,
         CommunityDirectoryModelAdmin,
         OnlineWorshipModelAdmin,
         PublicBoardDocumentModelAdmin,

--- a/contact/views.py
+++ b/contact/views.py
@@ -1,7 +1,7 @@
 from wagtail.admin.ui.tables import Column
 from wagtail.admin.viewsets.base import ViewSetGroup
 from wagtail.admin.viewsets.pages import PageListingViewSet
-
+from memorials.views import MemorialViewSet
 from .models import (
     Meeting,
     Organization,
@@ -70,4 +70,5 @@ class ContactViewSetGroup(ViewSetGroup):
         PersonViewSet,
         MeetingViewSet,
         OrganizationViewSet,
+        MemorialViewSet,
     ]

--- a/memorials/views.py
+++ b/memorials/views.py
@@ -1,0 +1,24 @@
+from wagtail.admin.ui.tables import Column
+from wagtail.admin.viewsets.pages import PageListingViewSet
+
+from .models import Memorial
+
+
+class MemorialViewSet(PageListingViewSet):
+    model = Memorial
+    menu_label = "Memorials"
+    name = "memorials"
+    icon = "user"
+    columns = [
+        Column(
+            "memorial_person",
+            label="Person",
+            sort_key="memorial_person",
+        ),
+        Column(
+            "memorial_meeting",
+            label="Meeting",
+            sort_key="memorial_meeting",
+        ),
+    ]
+    search_fields = ["full_name", "memorial_meeting"]


### PR DESCRIPTION
This pull request adds the `MemorialViewSet` class and removes the `MemorialModelAdmin` class. The `MemorialViewSet` class is responsible for handling the API endpoints and Wagtail UI elements related to memorials, while the `MemorialModelAdmin` class is no longer needed. This change improves the organization and functionality of the codebase.