### PR TITLE
Refactor and migrate views and models

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -2,6 +2,7 @@ from http import HTTPStatus
 from django.shortcuts import render
 from wagtail.admin.viewsets.base import ViewSetGroup
 
+from community.views import CommunityDirectoryViewSet
 from events.views import EventViewSet
 
 
@@ -10,6 +11,7 @@ class ContentViewSetGroup(ViewSetGroup):
     menu_icon = "snippet"
     menu_order = 100
     items = [
+        CommunityDirectoryViewSet,
         EventViewSet,
     ]
 

--- a/common/views.py
+++ b/common/views.py
@@ -11,7 +11,7 @@ from wf_pages.views import MollyWingateBlogPageViewSet
 class ContentViewSetGroup(ViewSetGroup):
     menu_label = "Content"
     menu_icon = "snippet"
-    menu_order = 100
+    menu_order = 101
     items = [
         CommunityDirectoryViewSet,
         EventViewSet,

--- a/common/views.py
+++ b/common/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import render
 from wagtail.admin.viewsets.base import ViewSetGroup
 
 from community.views import CommunityDirectoryViewSet, OnlineWorshipViewSet
+from documents.views import MeetingDocumentViewSet, PublicBoardDocumentViewSet
 from events.views import EventViewSet
 
 
@@ -14,6 +15,8 @@ class ContentViewSetGroup(ViewSetGroup):
         CommunityDirectoryViewSet,
         EventViewSet,
         OnlineWorshipViewSet,
+        MeetingDocumentViewSet,
+        PublicBoardDocumentViewSet,
     ]
 
 

--- a/common/views.py
+++ b/common/views.py
@@ -1,5 +1,14 @@
 from http import HTTPStatus
 from django.shortcuts import render
+from wagtail.admin.viewsets.base import ViewSetGroup
+
+from events.views import EventViewSet
+
+
+class ContentViewSetGroup(ViewSetGroup):
+    menu_label = "Content"
+    menu_icon = "snippet"
+    items = [EventViewSet]
 
 
 def custom_404(request, exception=None):  # noqa: W0613 # skipcq: PYL-W0613

--- a/common/views.py
+++ b/common/views.py
@@ -5,6 +5,7 @@ from wagtail.admin.viewsets.base import ViewSetGroup
 from community.views import CommunityDirectoryViewSet, OnlineWorshipViewSet
 from documents.views import MeetingDocumentViewSet, PublicBoardDocumentViewSet
 from events.views import EventViewSet
+from wf_pages.views import MollyWingateBlogPageViewSet
 
 
 class ContentViewSetGroup(ViewSetGroup):
@@ -17,6 +18,7 @@ class ContentViewSetGroup(ViewSetGroup):
         OnlineWorshipViewSet,
         MeetingDocumentViewSet,
         PublicBoardDocumentViewSet,
+        MollyWingateBlogPageViewSet,
     ]
 
 

--- a/common/views.py
+++ b/common/views.py
@@ -8,7 +8,10 @@ from events.views import EventViewSet
 class ContentViewSetGroup(ViewSetGroup):
     menu_label = "Content"
     menu_icon = "snippet"
-    items = [EventViewSet]
+    menu_order = 100
+    items = [
+        EventViewSet,
+    ]
 
 
 def custom_404(request, exception=None):  # noqa: W0613 # skipcq: PYL-W0613

--- a/common/views.py
+++ b/common/views.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 from django.shortcuts import render
 from wagtail.admin.viewsets.base import ViewSetGroup
 
-from community.views import CommunityDirectoryViewSet
+from community.views import CommunityDirectoryViewSet, OnlineWorshipViewSet
 from events.views import EventViewSet
 
 
@@ -13,6 +13,7 @@ class ContentViewSetGroup(ViewSetGroup):
     items = [
         CommunityDirectoryViewSet,
         EventViewSet,
+        OnlineWorshipViewSet,
     ]
 
 

--- a/common/wagtail_hooks.py
+++ b/common/wagtail_hooks.py
@@ -1,0 +1,9 @@
+from wagtail import hooks
+from .views import (
+    ContentViewSetGroup,
+)
+
+
+@hooks.register("register_admin_viewset")
+def register_content_viewset_group():
+    return ContentViewSetGroup()

--- a/community/views.py
+++ b/community/views.py
@@ -1,6 +1,6 @@
 from wagtail.admin.viewsets.pages import PageListingViewSet
 
-from .models import CommunityDirectory
+from .models import CommunityDirectory, OnlineWorship
 
 
 class CommunityDirectoryViewSet(PageListingViewSet):
@@ -8,5 +8,14 @@ class CommunityDirectoryViewSet(PageListingViewSet):
     menu_label = "Directories"
     icon = "group"
     name = "directories"
+    search_fields = ["title"]
+    ordering = ["title"]
+
+
+class OnlineWorshipViewSet(PageListingViewSet):
+    model = OnlineWorship
+    menu_label = "Online Worship"
+    icon = "globe"
+    name = "online_worship"
     search_fields = ["title"]
     ordering = ["title"]

--- a/community/views.py
+++ b/community/views.py
@@ -1,0 +1,12 @@
+from wagtail.admin.viewsets.pages import PageListingViewSet
+
+from .models import CommunityDirectory
+
+
+class CommunityDirectoryViewSet(PageListingViewSet):
+    model = CommunityDirectory
+    menu_label = "Directories"
+    icon = "group"
+    name = "directories"
+    search_fields = ["title"]
+    ordering = ["title"]

--- a/community/wagtail_hooks.py
+++ b/community/wagtail_hooks.py
@@ -8,7 +8,6 @@ from wagtail_modeladmin.options import (
 )
 from wagtail import hooks
 
-from community.models import OnlineWorship
 from documents.models import MeetingDocument, PublicBoardDocument
 from wf_pages.models import MollyWingateBlogPage
 
@@ -31,19 +30,6 @@ class MollyWingateBlogPageModelAdmin(ModelAdmin):
         "publication_date",
         "live",
     )
-
-
-class OnlineWorshipModelAdmin(ModelAdmin):
-    model = OnlineWorship
-    menu_icon = "globe"
-    menu_label = "Online Worship"
-    list_per_page = 10
-    ordering = [
-        "title",
-    ]
-    list_display = ("title",)
-    empty_value_display = "-"
-    search_fields = ("title",)
 
 
 class PublicBoardDocumentModelAdmin(ModelAdmin):
@@ -87,7 +73,6 @@ class CommunityGroup(ModelAdminGroup):
     menu_icon = "snippet"
     menu_order = 200
     items = (
-        OnlineWorshipModelAdmin,
         PublicBoardDocumentModelAdmin,
         MeetingDocumentModelAdmin,
         MollyWingateBlogPageModelAdmin,

--- a/community/wagtail_hooks.py
+++ b/community/wagtail_hooks.py
@@ -1,44 +1,7 @@
 from django.conf import settings
 from django.utils.html import format_html_join
 from django.utils.safestring import SafeString
-from wagtail_modeladmin.options import (
-    ModelAdmin,
-    ModelAdminGroup,
-    modeladmin_register,
-)
 from wagtail import hooks
-
-from wf_pages.models import MollyWingateBlogPage
-
-
-class MollyWingateBlogPageModelAdmin(ModelAdmin):
-    model = MollyWingateBlogPage
-    menu_icon = "doc-full"
-    menu_label = "Molly Wingate Blog"
-    list_per_page = 10
-    ordering = [
-        "title",
-    ]
-    list_display = (
-        "title",
-        "publication_date",
-    )
-    empty_value_display = "-"
-    search_fields = ("title",)
-    list_filter = (
-        "publication_date",
-        "live",
-    )
-
-
-class CommunityGroup(ModelAdminGroup):
-    menu_label = "Community"
-    menu_icon = "snippet"
-    menu_order = 200
-    items = (MollyWingateBlogPageModelAdmin,)
-
-
-modeladmin_register(CommunityGroup)
 
 
 @hooks.register("insert_editor_js")  # type: ignore
@@ -46,9 +9,8 @@ def editor_js() -> SafeString:
     js_files = [
         "js/contact/person_url_slug.js",
     ]
-    js_includes = format_html_join(
+    return format_html_join(
         "\n",
         '<script src="{0}{1}"></script>',
         ((settings.STATIC_URL, filename) for filename in js_files),
     )
-    return js_includes

--- a/community/wagtail_hooks.py
+++ b/community/wagtail_hooks.py
@@ -10,7 +10,6 @@ from wagtail import hooks
 
 from community.models import CommunityDirectory, OnlineWorship
 from documents.models import MeetingDocument, PublicBoardDocument
-from events.models import Event
 from wf_pages.models import MollyWingateBlogPage
 
 
@@ -30,32 +29,6 @@ class MollyWingateBlogPageModelAdmin(ModelAdmin):
     search_fields = ("title",)
     list_filter = (
         "publication_date",
-        "live",
-    )
-
-
-class EventModelAdmin(ModelAdmin):
-    model = Event
-    menu_icon = "date"
-    menu_label = "Events"
-    menu_order = 200
-    add_to_settings_menu = False
-    exclude_from_explorer = False
-    list_per_page = 10
-    ordering = [
-        "-start_date",
-    ]
-    list_display = (
-        "title",
-        "start_date",
-        "end_date",
-        "live",
-    )
-    empty_value_display = "-"
-    search_fields = ("title",)
-    list_filter = (
-        "start_date",
-        "category",
         "live",
     )
 
@@ -127,7 +100,6 @@ class CommunityGroup(ModelAdminGroup):
     menu_icon = "snippet"
     menu_order = 200
     items = (
-        EventModelAdmin,
         CommunityDirectoryModelAdmin,
         OnlineWorshipModelAdmin,
         PublicBoardDocumentModelAdmin,

--- a/community/wagtail_hooks.py
+++ b/community/wagtail_hooks.py
@@ -8,7 +8,6 @@ from wagtail_modeladmin.options import (
 )
 from wagtail import hooks
 
-from documents.models import MeetingDocument, PublicBoardDocument
 from wf_pages.models import MollyWingateBlogPage
 
 
@@ -32,51 +31,11 @@ class MollyWingateBlogPageModelAdmin(ModelAdmin):
     )
 
 
-class PublicBoardDocumentModelAdmin(ModelAdmin):
-    model = PublicBoardDocument
-    menu_icon = "doc-full"
-    menu_label = "Public Board Documents"
-    list_per_page = 10
-    ordering = [
-        "title",
-    ]
-    list_display = ("title",)
-    empty_value_display = "-"
-    search_fields = ("title",)
-
-
-class MeetingDocumentModelAdmin(ModelAdmin):
-    model = MeetingDocument
-    menu_icon = "doc-full"
-    menu_label = "Meeting Documents"
-    list_per_page = 10
-    ordering = [
-        "title",
-    ]
-    list_display = (
-        "title",
-        "publication_date",
-        "publishing_meeting",
-        "document_type",
-    )
-    empty_value_display = "-"
-    search_fields = ("title",)
-    list_filter = (
-        "publication_date",
-        "document_type",
-        "live",
-    )
-
-
 class CommunityGroup(ModelAdminGroup):
     menu_label = "Community"
     menu_icon = "snippet"
     menu_order = 200
-    items = (
-        PublicBoardDocumentModelAdmin,
-        MeetingDocumentModelAdmin,
-        MollyWingateBlogPageModelAdmin,
-    )
+    items = (MollyWingateBlogPageModelAdmin,)
 
 
 modeladmin_register(CommunityGroup)

--- a/community/wagtail_hooks.py
+++ b/community/wagtail_hooks.py
@@ -8,7 +8,7 @@ from wagtail_modeladmin.options import (
 )
 from wagtail import hooks
 
-from community.models import CommunityDirectory, OnlineWorship
+from community.models import OnlineWorship
 from documents.models import MeetingDocument, PublicBoardDocument
 from wf_pages.models import MollyWingateBlogPage
 
@@ -31,19 +31,6 @@ class MollyWingateBlogPageModelAdmin(ModelAdmin):
         "publication_date",
         "live",
     )
-
-
-class CommunityDirectoryModelAdmin(ModelAdmin):
-    model = CommunityDirectory
-    menu_icon = "group"
-    menu_label = "Directories"
-    list_per_page = 10
-    ordering = [
-        "title",
-    ]
-    list_display = ("title",)
-    empty_value_display = "-"
-    search_fields = ("title",)
 
 
 class OnlineWorshipModelAdmin(ModelAdmin):
@@ -100,7 +87,6 @@ class CommunityGroup(ModelAdminGroup):
     menu_icon = "snippet"
     menu_order = 200
     items = (
-        CommunityDirectoryModelAdmin,
         OnlineWorshipModelAdmin,
         PublicBoardDocumentModelAdmin,
         MeetingDocumentModelAdmin,

--- a/contact/views.py
+++ b/contact/views.py
@@ -14,7 +14,6 @@ class PersonViewSet(PageListingViewSet):
     menu_label = "People"
     name = "people"
     icon = "user"
-    add_to_settings_menu = False
     columns = [
         Column(
             "given_name",
@@ -46,7 +45,6 @@ class MeetingViewSet(PageListingViewSet):
     menu_label = "Meetings"
     icon = "home"
     name = "meetings"
-    add_to_settings_menu = False
     search_fields = ["title"]
     filterset_class = MeetingFilterSet
     ordering = ["title"]
@@ -57,7 +55,6 @@ class OrganizationViewSet(PageListingViewSet):
     menu_label = "Organizations"
     icon = "group"
     name = "organizations"
-    add_to_settings_menu = False
     search_fields = ["title"]
     ordering = ["title"]
 

--- a/documents/views.py
+++ b/documents/views.py
@@ -1,1 +1,91 @@
-# Create your views here.
+import django_filters
+from wagtail.admin.filters import DateRangePickerWidget
+from wagtail.admin.ui.tables import Column, TitleColumn
+from wagtail.admin.viewsets.pages import PageListingViewSet
+
+from .models import PublicBoardDocument, MeetingDocument
+
+
+class PublicBoardDocumentFilterSet(PageListingViewSet.filterset_class):
+    publication_date = django_filters.DateFromToRangeFilter(
+        label="Publication Date",
+        widget=DateRangePickerWidget,
+    )
+
+    class Meta:
+        model = PublicBoardDocument
+        fields = [
+            "publication_date",
+            "category",
+            "live",
+        ]
+
+
+class PublicBoardDocumentViewSet(PageListingViewSet):
+    model = PublicBoardDocument
+    menu_label = "Public Board Documents"
+    icon = "doc-full"
+    name = "public_board_documents"
+    columns = [
+        TitleColumn(
+            "title",
+            label="Title",
+            sort_key="title",
+        ),
+        Column(
+            "publication_date",
+            label="Publication Date",
+            sort_key="publication_date",
+        ),
+    ]
+    search_fields = ["title"]
+    ordering = ["-publication_date"]
+    filterset_class = PublicBoardDocumentFilterSet
+
+
+class MeetingDocumentFilterSet(PageListingViewSet.filterset_class):
+    publication_date = django_filters.DateFromToRangeFilter(
+        label="Publication Date",
+        widget=DateRangePickerWidget,
+    )
+
+    class Meta:
+        model = MeetingDocument
+        fields = [
+            "publication_date",
+            "publishing_meeting",
+            "document_type",
+            "live",
+        ]
+
+
+class MeetingDocumentViewSet(PageListingViewSet):
+    model = MeetingDocument
+    menu_label = "Meeting Documents"
+    icon = "doc-full"
+    name = "meeting_documents"
+    columns = [
+        Column(
+            "title",
+            label="Title",
+            sort_key="title",
+        ),
+        Column(
+            "publication_date",
+            label="Publication Date",
+            sort_key="publication_date",
+        ),
+        Column(
+            "publishing_meeting",
+            label="Publishing Meeting",
+            sort_key="publishing_meeting",
+        ),
+        Column(
+            "document_type",
+            label="Document Type",
+            sort_key="document_type",
+        ),
+    ]
+    search_fields = ["title"]
+    ordering = ["-publication_date"]
+    filterset_class = MeetingDocumentFilterSet

--- a/events/views.py
+++ b/events/views.py
@@ -32,6 +32,7 @@ class EventViewSet(PageListingViewSet):
             "title",
             label="Title",
             sort_key="title",
+            classname="title",
         ),
         Column(
             "start_date",

--- a/events/views.py
+++ b/events/views.py
@@ -1,0 +1,30 @@
+from wagtail.admin.ui.tables import Column
+from wagtail.admin.viewsets.pages import PageListingViewSet
+
+from .models import Event
+
+
+class EventViewSet(PageListingViewSet):
+    model = Event
+    menu_label = "Events"
+    icon = "date"
+    name = "events"
+    columns = [
+        Column(
+            "title",
+            label="Title",
+            sort_key="title",
+        ),
+        Column(
+            "start_date",
+            label="Start Date",
+            sort_key="start_date",
+        ),
+        Column(
+            "end_date",
+            label="End Date",
+            sort_key="end_date",
+        ),
+    ]
+    search_fields = ["title"]
+    ordering = ["-start_date"]

--- a/events/views.py
+++ b/events/views.py
@@ -1,6 +1,7 @@
 import django_filters
 from wagtail.admin.filters import DateRangePickerWidget
 from wagtail.admin.ui.tables import Column
+from wagtail.admin.ui.tables.pages import PageTitleColumn
 from wagtail.admin.viewsets.pages import PageListingViewSet
 
 from .models import Event
@@ -27,7 +28,7 @@ class EventViewSet(PageListingViewSet):
     icon = "date"
     name = "events"
     columns = [
-        Column(
+        PageTitleColumn(
             "title",
             label="Title",
             sort_key="title",

--- a/events/views.py
+++ b/events/views.py
@@ -1,7 +1,24 @@
+import django_filters
+from wagtail.admin.filters import DateRangePickerWidget
 from wagtail.admin.ui.tables import Column
 from wagtail.admin.viewsets.pages import PageListingViewSet
 
 from .models import Event
+
+
+class EventFilterSet(PageListingViewSet.filterset_class):
+    start_date = django_filters.DateFromToRangeFilter(
+        label="Start Date",
+        widget=DateRangePickerWidget,
+    )
+
+    class Meta:
+        model = Event
+        fields = [
+            "start_date",
+            "category",
+            "live",
+        ]
 
 
 class EventViewSet(PageListingViewSet):
@@ -28,3 +45,4 @@ class EventViewSet(PageListingViewSet):
     ]
     search_fields = ["title"]
     ordering = ["-start_date"]
+    filterset_class = EventFilterSet

--- a/magazine/views.py
+++ b/magazine/views.py
@@ -48,6 +48,7 @@ class ArchiveIssueViewSet(PageListingViewSet):
             "title",
             label="Title",
             sort_key="title",
+            classname="title",
         ),
         DateColumn(
             "publication_date",
@@ -81,6 +82,7 @@ class MagazineDepartmentViewSet(PageListingViewSet):
             "title",
             label="Title",
             sort_key="title",
+            classname="title",
         ),
         BulkActionsColumn(
             "bulk_actions",
@@ -103,6 +105,7 @@ class MagazineIssueViewSet(PageListingViewSet):
             "title",
             label="Title",
             sort_key="title",
+            classname="title",
         ),
         DateColumn(
             "publication_date",

--- a/magazine/views.py
+++ b/magazine/views.py
@@ -8,6 +8,7 @@ from wagtail.admin.ui.tables.pages import (
     BulkActionsColumn,
     PageTitleColumn,
     PageStatusColumn,
+    NavigateToChildrenColumn,
 )
 from .models import (
     ArchiveIssue,
@@ -97,6 +98,27 @@ class MagazineIssueViewSet(PageListingViewSet):
     add_to_admin_menu = False
     search_fields = ("title",)
     filterset_class = MagazineIssueFilterSet
+    columns = [
+        PageTitleColumn(
+            "title",
+            label="Title",
+            sort_key="title",
+        ),
+        DateColumn(
+            "publication_date",
+            label="Publication Date",
+            sort_key="publication_date",
+        ),
+        PageStatusColumn(
+            "live",
+            label="Live",
+            sort_key="live",
+        ),
+        NavigateToChildrenColumn(
+            "navigate_to_children",
+            label="Navigate to Children",
+        ),
+    ]
 
 
 class MagazineViewSetGroup(ViewSetGroup):

--- a/magazine/views.py
+++ b/magazine/views.py
@@ -127,7 +127,7 @@ class MagazineIssueViewSet(PageListingViewSet):
 class MagazineViewSetGroup(ViewSetGroup):
     menu_label = "Magazine"
     menu_icon = "tablet-alt"
-    menu_order = 100
+    menu_order = 102
     items = (
         ArchiveIssueViewSet,
         MagazineDepartmentViewSet,

--- a/news/views.py
+++ b/news/views.py
@@ -34,6 +34,7 @@ class NewsItemViewSet(PageListingViewSet):
             "title",
             label="Title",
             sort_key="title",
+            classname="title",
         ),
         DateColumn(
             "publication_date",

--- a/wf_pages/views.py
+++ b/wf_pages/views.py
@@ -1,1 +1,45 @@
-# Create your views here.
+import django_filters
+from wagtail.admin.filters import DateRangePickerWidget
+from wagtail.admin.ui.tables import Column
+from wagtail.admin.ui.tables.pages import PageTitleColumn
+from wagtail.admin.viewsets.pages import PageListingViewSet
+
+
+from .models import MollyWingateBlogPage
+
+
+class MollyWingateBlogPageFilterSet(PageListingViewSet.filterset_class):
+    publication_date = django_filters.DateFromToRangeFilter(
+        label="Publication Date",
+        widget=DateRangePickerWidget,
+    )
+
+    class Meta:
+        model = MollyWingateBlogPage
+        fields = [
+            "publication_date",
+            "live",
+        ]
+
+
+class MollyWingateBlogPageViewSet(PageListingViewSet):
+    model = MollyWingateBlogPage
+    menu_label = "Molly Wingate Blog Pages"
+    icon = "list-ul"
+    name = "molly_wingate_blog_pages"
+    columns = [
+        PageTitleColumn(
+            "title",
+            label="Title",
+            sort_key="title",
+            classname="title",
+        ),
+        Column(
+            "publication_date",
+            label="Publication Date",
+            sort_key="publication_date",
+        ),
+    ]
+    search_fields = ["title"]
+    ordering = ["-publication_date"]
+    filterset_class = MollyWingateBlogPageFilterSet


### PR DESCRIPTION
Related to: #938

This pull request refactors and migrates several views and models in the codebase. It includes the following changes:

- Cleanup

- Add EventViewSet

- Add ContentViewSetGroup

- Move content higher in menu

- Add EventFilterSet

- Remove EventModelAdmin

- Migrate to CommunityDirectoryViewSet

- Migrate to OnlineWorshipViewSet

- Add NavigateToChildrenColumn

- Add PageTitleColumn

- Add classname="title"

- Migrate documents to PageListingViewSet

- Migrate to MollyWingateBlogPageViewSet

- Adjust menu weights