### PR TITLE
Update PayPal help text

### DIFF
--- a/payment/templates/payment/process.html
+++ b/payment/templates/payment/process.html
@@ -10,6 +10,8 @@
         information will ever be visible to Western Friend.
     </p>
 
+    <p class="text-muted">Although PayPal transacts all of Western Friend's online purchases, you can choose whether to pay with a credit card or a PayPal account. You do not need to have a PayPal account to make a payment here.</p>
+
     <p>Payment total: ${{ order.get_total_cost }}</p>
 
     <div id="paypal-button-container"></div>


### PR DESCRIPTION
Closes #1082

Updated the help text for the PayPal payment option to clarify that users can choose to pay with a credit card or a PayPal account, and that a PayPal account is not required to make a payment.