### PR TITLE
Standardize search result templates

### DIFF
--- a/search/templates/search/community_directory.html
+++ b/search/templates/search/community_directory.html
@@ -2,11 +2,11 @@
 
 <div class="card my-1">
     <div class="card-body">
-        <h3 class="panel-title">
+        <h2 class="card-title h5">
             <a href="{% pageurl entity %}">
                 {{ entity.title }}
             </a>
-        </h3>
+        </h2>
 
         {% if entity.specific.description %}
             {{ entity.specific.description | truncatewords_html:10 | richtext }}

--- a/search/templates/search/event.html
+++ b/search/templates/search/event.html
@@ -2,11 +2,11 @@
 
 <div class="card my-1">
     <div class="card-body">
-        <h3 class="panel-title">
+        <h2 class="card-title h5">
             <a href="{% pageurl entity %}">
                 {{ entity.title }}
             </a>
-        </h3>
+        </h2>
 
         {% if entity.specific.date %}
             {{ entity.specific.date }}

--- a/search/templates/search/magazine_article.html
+++ b/search/templates/search/magazine_article.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags %}
 <div class="card my-2">
     <div class="card-body">
-        <h2 class="card-title h4">
+        <h2 class="card-title h5">
             <a href="{% pageurl entity %}">
                 {{ entity.title }}
             </a>

--- a/search/templates/search/magazine_article.html
+++ b/search/templates/search/magazine_article.html
@@ -1,9 +1,11 @@
 {% load wagtailcore_tags %}
 <div class="card my-2">
     <div class="card-body">
-        <a href="{% pageurl entity %}" class="card-title lead">
-            {{ entity.title }}
-        </a>
+        <h2 class="card-title h4">
+            <a href="{% pageurl entity %}">
+                {{ entity.title }}
+            </a>
+        </h2>
 
         {% if entity.specific.authors.count %}
             <ul class="list-inline mb-1">

--- a/search/templates/search/magazine_issue.html
+++ b/search/templates/search/magazine_issue.html
@@ -2,11 +2,11 @@
 
 <div class="card my-1">
     <div class="card-body">
-        <h3 class="panel-title">
+        <h2 class="card-title h4">
             <a href="{% pageurl entity %}">
                 {{ entity.title }}
             </a>
-        </h3>
+        </h2>
 
         {% if entity.specific.publication_date %}
             <p class="card-text">

--- a/search/templates/search/magazine_issue.html
+++ b/search/templates/search/magazine_issue.html
@@ -2,7 +2,7 @@
 
 <div class="card my-1">
     <div class="card-body">
-        <h2 class="card-title h4">
+        <h2 class="card-title h5">
             <a href="{% pageurl entity %}">
                 {{ entity.title }}
             </a>

--- a/search/templates/search/meeting.html
+++ b/search/templates/search/meeting.html
@@ -2,11 +2,11 @@
 
 <div class="card my-1">
     <div class="card-body">
-        <h3 class="panel-title">
+        <h2 class="card-title h5">
             <a href="{% pageurl entity %}">
                 {{ entity.title }}
             </a>
-        </h3>
+        </h2>
 
         {% if entity.specific.description %}
             {{ entity.specific.description | truncatewords_html:10 | richtext }}

--- a/search/templates/search/online_worship.html
+++ b/search/templates/search/online_worship.html
@@ -9,7 +9,7 @@
         </h2>
 
         {% if entity.specific.description %}
-            <p class="card-text">{{ entity.specific.description | truncatewords_html:10 }}</p>
+            {{ entity.specific.description | truncatewords_html:10 | richtext }}
         {% endif %}
 
         {% if entity.specific.times_of_worship %}

--- a/search/templates/search/online_worship.html
+++ b/search/templates/search/online_worship.html
@@ -11,8 +11,5 @@
         {% if entity.specific.description %}
             {{ entity.specific.description | truncatewords_html:10 | richtext }}
         {% endif %}
-
-        {% if entity.specific.times_of_worship %}
-        {% endif %}
     </div>
 </div>

--- a/search/templates/search/online_worship.html
+++ b/search/templates/search/online_worship.html
@@ -14,6 +14,7 @@
 
         {% if entity.specific.times_of_worship %}
             <p class="card-text">
+                <strong>Times of worship:</strong>
                 {{ entity.specific.times_of_worship | richtext }}
             </p>
         {% endif %}

--- a/search/templates/search/online_worship.html
+++ b/search/templates/search/online_worship.html
@@ -13,10 +13,6 @@
         {% endif %}
 
         {% if entity.specific.times_of_worship %}
-            <p class="card-text">
-                <strong>Times of worship:</strong>
-                {{ entity.specific.times_of_worship | richtext }}
-            </p>
         {% endif %}
     </div>
 </div>

--- a/search/templates/search/online_worship.html
+++ b/search/templates/search/online_worship.html
@@ -2,7 +2,7 @@
 
 <div class="card my-1">
     <div class="card-body">
-        <h2 class="card-title h4">
+        <h2 class="card-title h5">
             <a href="{% pageurl entity %}">
                 {{ entity.title }}
             </a>

--- a/search/templates/search/online_worship.html
+++ b/search/templates/search/online_worship.html
@@ -2,19 +2,20 @@
 
 <div class="card my-1">
     <div class="card-body">
-        <h3 class="panel-title">
+        <h2 class="card-title h4">
             <a href="{% pageurl entity %}">
                 {{ entity.title }}
             </a>
-        </h3>
+        </h2>
 
         {% if entity.specific.description %}
-            {{ entity.specific.description | truncatewords_html:10 | richtext }}
+            <p class="card-text">{{ entity.specific.description | truncatewords_html:10 }}</p>
         {% endif %}
 
         {% if entity.specific.times_of_worship %}
-            <strong>Times of worship:</strong>
-            {{ entity.specific.times_of_worship | richtext }}
+            <p class="card-text">
+                {{ entity.specific.times_of_worship | richtext }}
+            </p>
         {% endif %}
     </div>
 </div>

--- a/search/templates/search/organization.html
+++ b/search/templates/search/organization.html
@@ -2,11 +2,11 @@
 
 <div class="card my-1">
     <div class="card-body">
-        <h3 class="panel-title">
+        <h2 class="card-title h5">
             <a href="{% pageurl entity %}">
                 {{ entity.title }}
             </a>
-        </h3>
+        </h2>
 
         {% if entity.specific.description %}
             {{ entity.specific.description | truncatewords_html:10 | richtext }}

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -34,7 +34,7 @@
             {% else %}
                 <div class="card my-1">
                     <div class="card-body">
-                        <h2 class="card-title h4">
+                        <h2 class="card-title h5">
                             <a href="{% pageurl result %}">
                                 {{result}}
                             </a>

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -34,9 +34,9 @@
             {% else %}
                 <div class="card my-1">
                     <div class="card-body">
-                        <h2 class="card-title">
+                        <h2 class="card-title h4">
                             <a href="{% pageurl result %}">
-                                {{result}} ({{ result.content_type.name }})
+                                {{result}}
                             </a>
                         </h2>
                     </div>

--- a/search/views.py
+++ b/search/views.py
@@ -11,7 +11,7 @@ def search(request: HttpRequest) -> HttpResponse:
     number_per_page = 10
 
     # Search
-    # Using the `or` operator to search for pages that contain any of the words
+    # Using the 'or' operator to search for pages that contain any of the words
     if search_query:
         search_results = Page.objects.live().search(
             search_query,


### PR DESCRIPTION
Closes #1066

Updates search result templates to follow a standardized format across the site.

- Standardizes the HTML structure of search result templates to use a Bootstrap card body format, ensuring a consistent appearance and layout. This includes updating titles to use an H2 element with Bootstrap classes for a smaller heading appearance and wrapping titles in a card title link.
- Removes the content type in parentheses next to the title across all search templates, aligning with the desired outcome for a cleaner and more uniform display of search results.
- Adjusts the fallback display in `search/templates/search/search.html` for search results without a specific template to also use the Bootstrap card body format and removes the content type in parentheses next to the title, ensuring consistency even when a specific template is not available.
- Maintains the functionality of the search feature in `search/views.py`, ensuring that the search results are correctly rendered using the updated templates without altering the core search functionality.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/WesternFriend/westernfriend.org/issues/1066?shareId=19a22b36-bf4c-40c4-9800-f9ea59098990).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request standardizes the search result templates across the site by updating the HTML structure to use a Bootstrap card body format, ensuring consistent appearance and layout. It also removes the content type in parentheses next to the title for a cleaner display and maintains the core search functionality.

- **Enhancements**:
    - Standardized the HTML structure of search result templates to use a Bootstrap card body format for consistent appearance and layout.
    - Updated titles in search result templates to use an H2 element with Bootstrap classes for a smaller heading appearance and wrapped titles in a card title link.
    - Removed the content type in parentheses next to the title across all search templates for a cleaner and more uniform display of search results.
    - Adjusted the fallback display in `search/templates/search/search.html` to use the Bootstrap card body format and removed the content type in parentheses next to the title.

<!-- Generated by sourcery-ai[bot]: end summary -->