### PR TITLE
Remove postAttachCommand and make NavigationPageBlock null safe

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,8 +18,5 @@
   },
   "forwardPorts": [8000],
   "updateContentCommand": "pip install -r requirements.txt && python manage.py migrate && pre-commit install && python manage.py scaffold_initial_content",
-  "postCreateCommand": "cp .env.example .env",
-  "postAttachCommand": {
-    "server": "python manage.py runserver 0.0.0.0:8000"
-  }
+  "postCreateCommand": "cp .env.example .env"
 }

--- a/navigation/blocks.py
+++ b/navigation/blocks.py
@@ -36,12 +36,21 @@ class NavigationExternalLinkBlock(wagtail_blocks.StructBlock):
 class NavigationPageChooserStructValue(StructValue):
     def href(self):
         """Construct a URL with anchor if exists, otherwise use URL."""
-        url = self.get("page").url
+        page = self.get("page")
+        if page is None:
+            url = "#"  # or some other default URL
+        else:
+            url = page.url
         anchor = self.get("anchor")
 
-        href = f"{url}#{anchor}" if anchor else url
-
-        return href
+        if url and anchor:
+            return f"{url}#{anchor}"
+        elif url:
+            return url
+        elif anchor:
+            return f"#{anchor}"
+        else:
+            return "#"
 
 
 class NavigationPageChooserBlock(wagtail_blocks.StructBlock):


### PR DESCRIPTION
This pull request removes the `postAttachCommand` from the configuration file and makes the `NavigationPageBlock` null safe. The `postAttachCommand` was unnecessary and can be safely removed. The `NavigationPageBlock` now handles null values for the `page` field, providing a default URL if the page is null and constructing a URL with an anchor if the anchor exists.