### PR TITLE
Add nofollow and ARIA labels, Adjust menu layout

### DIFF
--- a/core/templates/navbar.html
+++ b/core/templates/navbar.html
@@ -1,7 +1,7 @@
 {% load wagtailsettings_tags %}
 {% get_settings use_default_site=True %}
 
-<nav class="navbar navbar-expand-lg navbar-dark pb-0 shadow-sm" style="background-color: #000;">
+<nav class="navbar navbar-expand-lg navbar-dark pb-0 shadow-sm" style="background-color: #000;" aria-label="Main navigation">
     <div class="container">
         <button class="navbar-toggler mb-2" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse"
                 aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
@@ -9,33 +9,37 @@
         </button>
 
         <div class="collapse navbar-collapse" id="navbarCollapse">
-            <ul class="navbar-nav website-links">
+            <ul class="navbar-nav website-links" role="menubar">
                 {{ settings.navigation.NavigationMenuSetting.menu_items }}
             </ul>
-            <ul class="navbar-nav ms-auto">
-                <li class="navbar-nav me-2">
+            <ul class="navbar-nav ms-auto" role="menubar">
+                <li class="nav-item" role="none">
                     {% if user.is_authenticated %}
                         <form id="logout-form" method="post" action="{% url 'logout' %}?next={{ request.path }}">
                             {% csrf_token %}
-                            <button type="submit">Log out</button>
+                            <button type="submit" class="btn btn-link nav-link" role="menuitem">Log out</button>
                         </form>
                     {% else %}
-                        <a href="{% url 'login' %}?next={{ request.path }}" class="nav-link">
+                        <a href="{% url 'login' %}?next={{ request.path }}" class="nav-link" rel="nofollow" role="menuitem">
                             Login
-                        </a>
-                        <a href="{% url 'django_registration_register' %}" class="nav-link">
-                            Register
                         </a>
                     {% endif %}
                 </li>
+                {% if not user.is_authenticated %}
+                    <li class="nav-item" role="none">
+                        <a href="{% url 'django_registration_register' %}" class="nav-link" rel="nofollow" role="menuitem">
+                            Register
+                        </a>
+                    </li>
+                {% endif %}
             </ul>
 
-            <form action="{% url 'search' %}" method="get" class="form-inline mb-2">
+            <form action="{% url 'search' %}" method="get" class="form-inline mb-2" role="search">
                 <div class="input-group">
-                    <input id="navbar-search-input" name="query" type="text" class="form-control" placeholder="Search" aria-label="Search" />
-
-                    <button class="btn btn-outline-light" type="submit" aria-label="Submit query">
-                        <i class="bi bi-search"></i>
+                    <label for="navbar-search-input" class="visually-hidden">Search</label>
+                    <input id="navbar-search-input" name="query" type="search" class="form-control" placeholder="Search" aria-label="Search" />
+                    <button class="btn btn-outline-light" type="submit" aria-label="Submit search">
+                        <i class="bi bi-search" aria-hidden="true"></i>
                     </button>
                 </div>
             </form>

--- a/core/templates/navbar.html
+++ b/core/templates/navbar.html
@@ -12,7 +12,7 @@
             <ul class="navbar-nav website-links" role="menubar">
                 {{ settings.navigation.NavigationMenuSetting.menu_items }}
             </ul>
-            <ul class="navbar-nav ms-auto" role="menubar">
+            <ul class="navbar-nav ms-auto me-lg-3" role="menubar">
                 <li class="nav-item" role="none">
                     {% if user.is_authenticated %}
                         <form id="logout-form" method="post" action="{% url 'logout' %}?next={{ request.path }}">
@@ -34,7 +34,7 @@
                 {% endif %}
             </ul>
 
-            <form action="{% url 'search' %}" method="get" class="form-inline mb-2" role="search">
+            <form action="{% url 'search' %}" method="get" class="form-inline mb-2 mb-lg-0" role="search">
                 <div class="input-group">
                     <label for="navbar-search-input" class="visually-hidden">Search</label>
                     <input id="navbar-search-input" name="query" type="search" class="form-control" placeholder="Search" aria-label="Search" />


### PR DESCRIPTION
This pull request includes changes to add `nofollow` and ARIA labels to the navigation menu links, as well as adjustments to the layout of the menu. The `navbar` element now has an `aria-label` attribute for accessibility. The user authentication and registration links have been updated to include the `rel="nofollow"` attribute. Additionally, the search form now includes a visually hidden label for accessibility.