### PR TITLE
Added metadata to events page

### DIFF
--- a/events/templates/events/event.html
+++ b/events/templates/events/event.html
@@ -8,55 +8,36 @@
 {% block title %}{{ page.title }}{% endblock %}
 
 {% block content %}
-
-
-<script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "Event",
-    "name": "{{ event.title|escapejs }}",
-    "startDate": "{% if event.start_date %}{{ event.start_date|date:'c' }}{% endif %}",
-    "endDate": "{% if event.end_date %}{{ event.end_date|date:'c' }}{% endif %}",
-    "eventStatus": "https://schema.org/EventScheduled",
-    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-    "description": "{{ event.body|striptags|escapejs }}",
-    "url": "{{ request.build_absolute_uri }}",
-    "eventCategory": "{{ event.get_category_display|escapejs }}",  <!-- Dynamic event category based on choices -->
-    "eventWebsite": "{% if event.website %}{{ event.website }}{% endif %}"
-  }
-</script>
-
-
 <a href="{% pageurl page.get_parent %}?category={{ page.category }}">
-  Events
+    Events
 </a>
 
 <h1>{{ event.title }}</h1>
 
 <p class="font-weight-bold mb-2">
-  {% if event.start_date %}
-  {{ event.start_date | timezone:"US/Pacific" | date:"F d, Y, f A" }}
-  {% endif %}
+    {% if event.start_date %}
+    {{ event.start_date | timezone:"US/Pacific" | date:"F d, Y, f A" }}
+    {% endif %}
 
-  {% if event.end_date %}
-  -
-  {{ event.end_date | timezone:"US/Pacific" | date:"F d, Y, f A" }}
-  {% endif %}
+    {% if event.end_date %}
+    -
+    {{ event.end_date | timezone:"US/Pacific" | date:"F d, Y, f A" }}
+    {% endif %}
 
-  US/Pacific
+    US/Pacific
 </p>
 
 {% if event.sponsors.all %}
 <dt class="col-sm-2">Sponsor(s):</dt>
 <dd class="col-sm-10">
-  {% for sponsor in event.sponsors.all %}
-  {% if sponsor.sponsor.live %}
-  <a href="{% pageurl sponsor.sponsor %}">
-    {{ sponsor.sponsor }}</a>{% if not forloop.last %},{% endif %}
-  {% else %}
-  {{ sponsor.sponsor }}{% if not forloop.last %},{% endif %}
-  {% endif %}
-  {% endfor %}
+    {% for sponsor in event.sponsors.all %}
+    {% if sponsor.sponsor.live %}
+    <a href="{% pageurl sponsor.sponsor %}">
+        {{ sponsor.sponsor }}</a>{% if not forloop.last %},{% endif %}
+    {% else %}
+    {{ sponsor.sponsor }}{% if not forloop.last %},{% endif %}
+    {% endif %}
+    {% endfor %}
 </dd>
 {% endif %}
 
@@ -67,8 +48,28 @@
 
 {% if event.website %}
 <a href="{{ event.specific.website }}" class="btn btn-primary btn-sm" target="blank">
-  <i class="bi bi-link" aria-hidden="true"></i>
-  Visit event website
+    <i class="bi bi-link" aria-hidden="true"></i>
+    Visit event website
 </a>
 {% endif %}
 {% endblock %}
+
+{% block extra_js %}
+
+    <script type="application/ld+json">
+        {
+        "@context": "https://schema.org",
+        "@type": "Event",
+        "name": "{{ event.title|escapejs }}",
+        "startDate": "{% if event.start_date %}{{ event.start_date|date:'c' }}{% endif %}",
+        "endDate": "{% if event.end_date %}{{ event.end_date|date:'c' }}{% endif %}",
+        "eventStatus": "https://schema.org/EventScheduled",
+        "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+        "description": "{{ event.body|striptags|escapejs }}",
+        "url": "{{ request.build_absolute_uri }}",
+        "eventCategory": "{{ event.get_category_display|escapejs }}",  <!-- Dynamic event category based on choices -->
+        "eventWebsite": "{% if event.website %}{{ event.website }}{% endif %}"
+        }
+    </script>
+
+{% endblock extra_js %}

--- a/events/templates/events/event.html
+++ b/events/templates/events/event.html
@@ -8,52 +8,67 @@
 {% block title %}{{ page.title }}{% endblock %}
 
 {% block content %}
-    <a href="{% pageurl page.get_parent %}?caegory={{ page.category }}">
-        Events
-    </a>
-
-    <h1>{{ event.title }}</h1>
-
-    <p class="font-weight-bold mb-2">
-        {% if event.start_date %}
-            {{ event.start_date | timezone:"US/Pacific" | date:"F d, Y, f A" }}
-        {% endif %}
-
-        {% if event.end_date %}
-            -
-            {{ event.end_date | timezone:"US/Pacific" | date:"F d, Y, f A" }}
-        {% endif %}
-
-        US/Pacific
-    </p>
-
-    {% if event.sponsors.all %}
-        <dt class="col-sm-2">Sponsor(s):</dt>
-        <dd class="col-sm-10">
-            {% for sponsor in event.sponsors.all %}
-                {% if sponsor.sponsor.live %}
-                    <a href="{% pageurl sponsor.sponsor %}">
-                        {{ sponsor.sponsor }}</a>{% if not forloop.last %},{% endif %}
-                {% else %}
-                    {{ sponsor.sponsor }}{% if not forloop.last %},{% endif %}
-                {% endif %}
-            {% endfor %}
-        </dd>
-    {% endif %}
 
 
-    {% if event.body %}
-        {{ event.body }}
-    {% endif %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    "name": "{{ event.title|escapejs }}",
+    "startDate": "{% if event.start_date %}{{ event.start_date|date:'c' }}{% endif %}",
+    "endDate": "{% if event.end_date %}{{ event.end_date|date:'c' }}{% endif %}",
+    "eventStatus": "https://schema.org/EventScheduled",
+    "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+    "description": "{{ event.body|striptags|escapejs }}",
+    "url": "{{ request.build_absolute_uri }}",
+    "eventCategory": "{{ event.get_category_display|escapejs }}",  <!-- Dynamic event category based on choices -->
+    "eventWebsite": "{% if event.website %}{{ event.website }}{% endif %}"
+  }
+</script>
 
-    {% if event.website %}
-        <a
-            href="{{ event.specific.website }}"
-            class="btn btn-primary btn-sm"
-            target="blank"
-        >
-            <i class="bi bi-link" aria-hidden="true"></i>
-            Visit event website
-        </a>
-    {% endif %}
+
+<a href="{% pageurl page.get_parent %}?category={{ page.category }}">
+  Events
+</a>
+
+<h1>{{ event.title }}</h1>
+
+<p class="font-weight-bold mb-2">
+  {% if event.start_date %}
+  {{ event.start_date | timezone:"US/Pacific" | date:"F d, Y, f A" }}
+  {% endif %}
+
+  {% if event.end_date %}
+  -
+  {{ event.end_date | timezone:"US/Pacific" | date:"F d, Y, f A" }}
+  {% endif %}
+
+  US/Pacific
+</p>
+
+{% if event.sponsors.all %}
+<dt class="col-sm-2">Sponsor(s):</dt>
+<dd class="col-sm-10">
+  {% for sponsor in event.sponsors.all %}
+  {% if sponsor.sponsor.live %}
+  <a href="{% pageurl sponsor.sponsor %}">
+    {{ sponsor.sponsor }}</a>{% if not forloop.last %},{% endif %}
+  {% else %}
+  {{ sponsor.sponsor }}{% if not forloop.last %},{% endif %}
+  {% endif %}
+  {% endfor %}
+</dd>
+{% endif %}
+
+
+{% if event.body %}
+{{ event.body }}
+{% endif %}
+
+{% if event.website %}
+<a href="{{ event.specific.website }}" class="btn btn-primary btn-sm" target="blank">
+  <i class="bi bi-link" aria-hidden="true"></i>
+  Visit event website
+</a>
+{% endif %}
 {% endblock %}

--- a/events/templates/events/event.html
+++ b/events/templates/events/event.html
@@ -55,17 +55,17 @@
 {% block extra_js %}
     <script type="application/ld+json">
         {
-        "@context": "https://schema.org",
-        "@type": "Event",
-        "name": "{{ event.title|escapejs }}",
-        "startDate": "{% if event.start_date %}{{ event.start_date|date:'c' }}{% endif %}",
-        "endDate": "{% if event.end_date %}{{ event.end_date|date:'c' }}{% endif %}",
-        "eventStatus": "https://schema.org/EventScheduled",
-        "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-        "description": "{{ event.body|striptags|escapejs }}",
-        "url": "{{ request.build_absolute_uri }}",
-        "eventCategory": "{{ event.get_category_display|escapejs }}",  <!-- Dynamic event category based on choices -->
-        "eventWebsite": "{% if event.website %}{{ event.website }}{% endif %}"
+            "@context": "https://schema.org",
+            "@type": "Event",
+            "name": "{{ event.title|escapejs }}",
+            "startDate": "{% if event.start_date %}{{ event.start_date|date:'c' }}{% endif %}",
+            "endDate": "{% if event.end_date %}{{ event.end_date|date:'c' }}{% endif %}",
+            "eventStatus": "https://schema.org/EventScheduled",
+            "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+            "description": "{{ event.body|striptags|escapejs }}",
+            "url": "{{ request.build_absolute_uri }}",
+            "eventCategory": "{{ event.get_category_display|escapejs }}",  <!-- Dynamic event category based on choices -->
+            "eventWebsite": "{% if event.website %}{{ event.website }}{% endif %}"
         }
     </script>
 {% endblock %}

--- a/events/templates/events/event.html
+++ b/events/templates/events/event.html
@@ -1,61 +1,58 @@
-{% extends "base.html" %}
+{% extends 'base.html' %}
 
 {% load tz %}
 {% load static wagtailcore_tags %}
 
-{% block body_class %}template-event{% endblock %}
+{% block body_class %}
+    template-event
+{% endblock %}
 
-{% block title %}{{ page.title }}{% endblock %}
+{% block title %}
+    {{ page.title }}
+{% endblock %}
 
 {% block content %}
-<a href="{% pageurl page.get_parent %}?category={{ page.category }}">
-    Events
-</a>
+    <a href="{% pageurl page.get_parent %}?category={{ page.category }}">Events</a>
 
-<h1>{{ event.title }}</h1>
+    <h1>{{ event.title }}</h1>
 
-<p class="font-weight-bold mb-2">
-    {% if event.start_date %}
-    {{ event.start_date | timezone:"US/Pacific" | date:"F d, Y, f A" }}
+    <p class="font-weight-bold mb-2">
+        {% if event.start_date %}
+            {{ event.start_date|timezone:'US/Pacific'|date:'F d, Y, f A' }}
+        {% endif %}
+
+        {% if event.end_date %}
+            -
+            {{ event.end_date|timezone:'US/Pacific'|date:'F d, Y, f A' }}
+        {% endif %}US/Pacific
+    </p>
+
+    {% if event.sponsors.all %}
+        <dt class="col-sm-2">Sponsor(s):</dt>
+        <dd class="col-sm-10">
+            {% for sponsor in event.sponsors.all %}
+                {% if sponsor.sponsor.live %}
+                    <a href="{% pageurl sponsor.sponsor %}">{{ sponsor.sponsor }}</a>{% if not forloop.last %},{% endif %}
+                {% else %}
+                    {{ sponsor.sponsor }}{% if not forloop.last %},{% endif %}
+                {% endif %}
+            {% endfor %}
+        </dd>
     {% endif %}
 
-    {% if event.end_date %}
-    -
-    {{ event.end_date | timezone:"US/Pacific" | date:"F d, Y, f A" }}
+    {% if event.body %}
+        {{ event.body }}
     {% endif %}
 
-    US/Pacific
-</p>
-
-{% if event.sponsors.all %}
-<dt class="col-sm-2">Sponsor(s):</dt>
-<dd class="col-sm-10">
-    {% for sponsor in event.sponsors.all %}
-    {% if sponsor.sponsor.live %}
-    <a href="{% pageurl sponsor.sponsor %}">
-        {{ sponsor.sponsor }}</a>{% if not forloop.last %},{% endif %}
-    {% else %}
-    {{ sponsor.sponsor }}{% if not forloop.last %},{% endif %}
+    {% if event.website %}
+        <a href="{{ event.specific.website }}" class="btn btn-primary btn-sm" target="blank">
+            <i class="bi bi-link" aria-hidden="true"></i>
+            Visit event website
+        </a>
     {% endif %}
-    {% endfor %}
-</dd>
-{% endif %}
-
-
-{% if event.body %}
-{{ event.body }}
-{% endif %}
-
-{% if event.website %}
-<a href="{{ event.specific.website }}" class="btn btn-primary btn-sm" target="blank">
-    <i class="bi bi-link" aria-hidden="true"></i>
-    Visit event website
-</a>
-{% endif %}
 {% endblock %}
 
 {% block extra_js %}
-
     <script type="application/ld+json">
         {
         "@context": "https://schema.org",
@@ -71,5 +68,4 @@
         "eventWebsite": "{% if event.website %}{{ event.website }}{% endif %}"
         }
     </script>
-
-{% endblock extra_js %}
+{% endblock %}

--- a/events/templates/events/event.html
+++ b/events/templates/events/event.html
@@ -64,7 +64,7 @@
             "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
             "description": "{{ event.body|striptags|escapejs }}",
             "url": "{{ request.build_absolute_uri }}",
-            "eventCategory": "{{ event.get_category_display|escapejs }}",  <!-- Dynamic event category based on choices -->
+            "eventCategory": "{{ event.get_category_display|escapejs }}",
             "eventWebsite": "{% if event.website %}{{ event.website }}{% endif %}"
         }
     </script>


### PR DESCRIPTION
### **User description**
issue #489 began the progress in doing it.


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Added JSON-LD structured data to the event page to improve SEO by providing search engines with detailed event metadata.
- Metadata includes event name, start and end dates, status, attendance mode, description, URL, category, and website.
- Ensured that the event category and website URL are dynamically included in the structured data.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>event.html</strong><dd><code>Add JSON-LD structured data for SEO enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

events/templates/events/event.html

<li>Added structured data using JSON-LD for SEO.<br> <li> Included metadata for event details like name, startDate, endDate, and <br>description.<br> <li> Ensured dynamic event category and website URL are included in <br>metadata.<br>


</details>


  </td>
  <td><a href="https://github.com/WesternFriend/westernfriend.org/pull/1119/files#diff-c748ba54220bdb9ebc99d739c5b2355616e840a888e1472bca2c2010d51fae5e">+64/-49</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

