### PR TITLE
Add note for password reset instructions

### DIFF
--- a/accounts/templates/registration/password_reset_form.html
+++ b/accounts/templates/registration/password_reset_form.html
@@ -3,6 +3,7 @@
 
 {% block content %}
     <h1>Password reset</h1>
+    <p><em>PLEASE NOTE:</em><br/> If you do not receive a password-reset message promptly after submitting this form, then please instead try registering for a new account on our website.</p>
     <div class="row">
         <div class="col-md-6">
             <form method="post" action="">


### PR DESCRIPTION
Closes #1133 

Include a note advising users to register for a new account if they do not receive a password-reset message promptly.