### PR TITLE
Remove unnecessary max-w-fit class for better alignment handling

### DIFF
--- a/blocks/templates/blocks/blocks/formatted_image_block.html
+++ b/blocks/templates/blocks/blocks/formatted_image_block.html
@@ -9,8 +9,9 @@
            {% elif value.align == 'left' %}
                float-left mr-4 clear-left
            {% else %}
-               mx-auto max-w-fit
+               mx-auto
            {% endif %}"
+    style="width: min({{ value.width }}px, 100%);"
 >
     {% if value.link %}
         <a href="{{ value.link }}" class="block">


### PR DESCRIPTION
Eliminate the max-w-fit class to improve alignment and ensure proper width handling for elements.

## Summary by Sourcery

Remove unnecessary max-w-fit class from center-aligned formatted images and add an inline style to constrain their width using min(value.width, 100%) for better alignment and responsive sizing

Enhancements:
- Eliminate the max-w-fit utility on center-aligned images to allow natural width handling
- Add an inline style on formatted images to cap their width at the lesser of the specified value and 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved image alignment and sizing by updating CSS classes and adding an inline style to ensure images do not exceed the container width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->