### PR TITLE
Update body rendering for improved flexibility

### DIFF
--- a/wf_pages/templates/wf_pages/molly_wingate_blog_page.html
+++ b/wf_pages/templates/wf_pages/molly_wingate_blog_page.html
@@ -26,7 +26,7 @@
             </header>
 
             <div class="prose dark:prose-invert">
-                {{ page.body|richtext }}
+                {% include_block page.body %}
             </div>
         </article>
     </main>


### PR DESCRIPTION
Switch to using `include_block` for rendering the page body to enhance flexibility in content management.

## Summary by Sourcery

Enhancements:
- Replace the richtext filter with include_block when rendering page body in templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated blog page content rendering to support more complex or structured content display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->