### PR TITLE
Remove search specific template

### DIFF
--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -38,19 +38,15 @@
         {% if paginated_search_results %}
             <div class="space-y-4">
                 {% for result in paginated_search_results.page %}
-                    {% if result.specific.search_template %}
-                        {% include result.specific.search_template with entity=result %}
-                    {% else %}
-                        <article class="card bg-base-100 shadow">
-                            <div class="card-body">
-                                <h2 class="card-title text-lg">
-                                    <a href="{% pageurl result %}">
-                                        {{ result }}
-                                    </a>
-                                </h2>
-                            </div>
-                        </article>
-                    {% endif %}
+                    <article class="card bg-base-100 shadow">
+                        <div class="card-body">
+                            <h2 class="card-title text-lg">
+                                <a href="{% pageurl result %}">
+                                    {{ result }}
+                                </a>
+                            </h2>
+                        </div>
+                    </article>
                 {% endfor %}
             </div>
 

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -36,19 +36,21 @@
 
     <section aria-live="polite" aria-label="Search results">
         {% if paginated_search_results %}
-            <div class="space-y-4">
+            <ul role="list" class="list-none space-y-4">
                 {% for result in paginated_search_results.page %}
-                    <article class="card bg-base-100 shadow">
-                        <div class="card-body">
-                            <h2 class="card-title text-lg">
-                                <a href="{% pageurl result %}">
-                                    {{ result }}
-                                </a>
-                            </h2>
-                        </div>
-                    </article>
+                    <li role="listitem">
+                        <article class="card bg-base-100 shadow">
+                            <div class="card-body">
+                                <h2 class="card-title text-lg">
+                                    <a href="{% pageurl result %}">
+                                        {{ result }}
+                                    </a>
+                                </h2>
+                            </div>
+                        </article>
+                    </li>
                 {% endfor %}
-            </div>
+            </ul>
 
             {% include "paginator.html" with paginated_items=paginated_search_results current_querystring=search_querystring %}
         {% elif search_query %}

--- a/search/views.py
+++ b/search/views.py
@@ -22,15 +22,6 @@ def search(request: HttpRequest) -> HttpResponse:
                 "content_type",
                 "locale",
             )
-            .prefetch_related(  # Prefetch related fields to avoid N+1 queries
-                # For magazine articles - prefetch authors and departments
-                "magazinearticle__authors__author",
-                "magazinearticle__department",
-                # For magazine issues - prefetch cover images
-                "magazineissue__cover_image",
-                # For archive issues - prefetch archive articles and their authors
-                "archiveissue__archive_articles__archive_authors__author",
-            )
             .search(
                 search_query,
                 operator="or",

--- a/theme/static/css/dist/styles.css
+++ b/theme/static/css/dist/styles.css
@@ -2565,9 +2565,6 @@
   .max-w-4xl {
     max-width: var(--container-4xl);
   }
-  .max-w-fit {
-    max-width: fit-content;
-  }
   .max-w-full {
     max-width: 100%;
   }


### PR DESCRIPTION
This pull request simplifies the search functionality by removing unused template logic and unnecessary database query prefetching. These changes streamline the codebase and improve maintainability.

### Template simplifications:

* Removed conditional logic for including specific search templates in `search/templates/search/search.html`, simplifying the structure of the search results rendering. [[1]](diffhunk://#diff-4bb7f04643aab3fbde72a04baeef469558bc452dc10a98b02e197abb3a0562c7L41-L43) [[2]](diffhunk://#diff-4bb7f04643aab3fbde72a04baeef469558bc452dc10a98b02e197abb3a0562c7L53)

### Query optimizations:

* Eliminated prefetching of related fields in the `search` view in `search/views.py`, reducing complexity and potential overhead from unused database queries.

## Summary by Sourcery

Streamline search functionality by removing unused template logic for specific search results and eliminating unnecessary database prefetching in the search view

Enhancements:
- Simplify search results template by removing conditional include logic
- Remove prefetch_related of unused related fields in the search view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified the display of search results to use a single consistent card layout, removing custom templates for different result types.
  - Modified database query optimization in the search view by removing certain prefetch operations, which may affect the speed of loading related data for search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->